### PR TITLE
Adding baseline selection function.

### DIFF
--- a/src/direct_optimal_mapping/data_conditioning.py
+++ b/src/direct_optimal_mapping/data_conditioning.py
@@ -33,6 +33,30 @@ class DataConditioning:
                                       inplace=False, keep_all_metadata=False)
         self.log = ['Init., freq. and pol. selected.',]
 
+    def bl_selection(self, ew_proj=14.):
+        '''Selecting the baselines with ew projection greater than a certain value.
+        This selection is necessary because the cross-talk suppression does not work
+        for those baselines. Details can be found in Kern et al. 2019, 2020
+        
+        Parameters
+        ----------
+        ew_proj: float
+            baseline selection criteria, regarding to the projected EW distance.
+            Default: 14; Unit: meter
+        
+        Return
+        ------
+        None
+        '''
+        idx_sel = np.where(np.abs(self.uv_1d.uvw_array[:, 0]) > ew_proj)[0]
+        if len(idx_sel) == 0:
+            return None
+        self.uv_1d.select(blt_inds=idx_sel, inplace=True, keep_all_metadata=False)
+        self.log.append('bl selected.')
+        if 'Noise calculated.' in self.log:
+            raise RuntimeError('bl selection should happen before noise calculation.')
+        return
+        
     def noise_calc(self):
         '''Calculating noise from the autocorrelations
         '''

--- a/src/direct_optimal_mapping/data_conditioning.py
+++ b/src/direct_optimal_mapping/data_conditioning.py
@@ -52,7 +52,7 @@ class DataConditioning:
         if len(idx_sel) == 0:
             return None
         self.uv_1d.select(blt_inds=idx_sel, inplace=True, keep_all_metadata=False)
-        self.log.append('bl selected.')
+        self.log.append('bl>%dm EW-projection selected.'%ew_proj)
         if 'Noise calculated.' in self.log:
             raise RuntimeError('bl selection should happen before noise calculation.')
         return

--- a/src/direct_optimal_mapping/data_conditioning.py
+++ b/src/direct_optimal_mapping/data_conditioning.py
@@ -22,6 +22,8 @@ class DataConditioning:
         ipol: integer [-5 - -8]
             select the linear polarization (-5:-8 (XX, YY, XY, YX))
         '''
+        if uv.phase_type != 'drift':
+            raise RuntimeError('Phase_type has to be drift for the data.')
         self.ifreq = ifreq
         self.ipol = ipol
         uv_cross = uv.select(ant_str='cross', inplace=False)


### PR DESCRIPTION
Baseline selection function is added to only select the baselines with projected EW distance >14m.
This is because the excluded baselines have cross-talk systematics that cannot be removed without significant EoR signal loss.